### PR TITLE
feat(dotnet): add .NET 9 SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ __pycache__/
 *.pyc
 *.egg-info/
 .venv/
+bin/
+obj/
+*.user
+artifacts/
+*.nupkg

--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ async def handle(msg):
 bot.run()
 ```
 
+### .NET 9
+
+```bash
+cd dotnet/examples/EchoBot
+dotnet run
+```
+
+```csharp
+using Pinix.WeixinBot;
+
+var bot = new WeixinBot();
+await bot.LoginAsync();
+
+bot.OnMessage(async message =>
+{
+    await bot.SendTypingAsync(message.UserId);
+    await bot.ReplyAsync(message, $"Echo: {message.Text}");
+});
+
+await bot.RunAsync();
+```
+
 ## 工作原理
 
 ```mermaid
@@ -122,6 +144,7 @@ sequenceDiagram
 - [Node.js Echo Bot](examples/nodejs/echo-bot.ts) — 完整示例，含日志和 typing
 - [Node.js 流式测试](examples/nodejs/stream-test.ts) — GENERATING vs FINISH 测试
 - [Node.js Typing 测试](examples/nodejs/generating-test.ts) — sendtyping vs GENERATING 对比
+- [.NET Echo Bot](dotnet/examples/EchoBot/Program.cs) — .NET 9 最小可运行示例
 
 ## 包
 
@@ -129,6 +152,7 @@ sequenceDiagram
 |---|---|---|
 | [@pinixai/weixin-bot](nodejs/) | `npm install @pinixai/weixin-bot` | [![npm](https://img.shields.io/npm/v/@pinixai/weixin-bot)](https://www.npmjs.com/package/@pinixai/weixin-bot) |
 | [weixin-bot-sdk](python/) | `pip install weixin-bot-sdk` | [![PyPI](https://img.shields.io/pypi/v/weixin-bot-sdk)](https://pypi.org/project/weixin-bot-sdk/) |
+| [Pinix.WeixinBot](dotnet/) | `dotnet add reference ./dotnet/src/Pinix.WeixinBot/Pinix.WeixinBot.csproj` | 本地 SDK / `net9.0` |
 
 ## License
 

--- a/dotnet/Pinix.WeixinBot.sln
+++ b/dotnet/Pinix.WeixinBot.sln
@@ -1,0 +1,54 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pinix.WeixinBot", "src\Pinix.WeixinBot\Pinix.WeixinBot.csproj", "{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoBot", "examples\EchoBot\EchoBot.csproj", "{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|x64.Build.0 = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Debug|x86.Build.0 = Debug|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|x64.ActiveCfg = Release|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|x64.Build.0 = Release|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|x86.ActiveCfg = Release|Any CPU
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE}.Release|x86.Build.0 = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|x64.Build.0 = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Debug|x86.Build.0 = Debug|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|x64.ActiveCfg = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|x64.Build.0 = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4EF876B1-1F20-48E2-918D-F8CA70CA1DCE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{E5AD3CE7-F014-4F96-9DC0-AB3015A0A0D7} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+EndGlobal

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,0 +1,113 @@
+# Pinix.WeixinBot
+
+.NET 9 SDK for the WeChat iLink Bot API.
+
+## Layout
+
+```text
+dotnet/
+├── src/Pinix.WeixinBot/   # SDK library
+├── examples/EchoBot/      # minimal example
+└── Pinix.WeixinBot.sln
+```
+
+## Requirements
+
+- .NET SDK `9.0`
+- No third-party runtime dependencies
+
+## Quick Start
+
+Run the included example:
+
+```bash
+cd dotnet/examples/EchoBot
+dotnet run
+```
+
+Use the library from another local project:
+
+```bash
+dotnet add <your-project>.csproj reference /path/to/weixin-bot/dotnet/src/Pinix.WeixinBot/Pinix.WeixinBot.csproj
+```
+
+```csharp
+using Pinix.WeixinBot;
+
+var bot = new WeixinBot();
+await bot.LoginAsync();
+
+bot.OnMessage(async message =>
+{
+    Console.WriteLine($"[{message.Timestamp:HH:mm:ss}] {message.UserId}: {message.Text}");
+    await bot.SendTypingAsync(message.UserId);
+    await bot.ReplyAsync(message, $"你说了: {message.Text}");
+});
+
+await bot.RunAsync();
+```
+
+## API
+
+### `new WeixinBot(options?)`
+
+Creates a bot client.
+
+- `BaseUrl`: override the iLink API base URL
+- `TokenPath`: override the credential file path
+- `OnError`: receive polling or handler errors
+
+### `await bot.LoginAsync(force: false)`
+
+Starts QR login if needed, stores credentials locally, and returns the active session.
+
+### `bot.OnMessage(handler)` / `bot.On("message", handler)`
+
+Registers a sync or async message handler. Inbound messages are normalized into:
+
+```csharp
+public sealed class IncomingMessage
+{
+    public string UserId { get; init; }
+    public string Text { get; init; }
+    public string Type { get; init; } // text | image | voice | file | video
+    public WeixinMessage Raw { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+}
+```
+
+### `await bot.ReplyAsync(message, text)`
+
+Replies with the inbound message's `context_token`. The SDK automatically stops typing in the background after sending the reply.
+
+### `await bot.SendTypingAsync(userId)`
+
+Shows the WeChat typing indicator. This only works after the SDK has seen at least one inbound message from that user.
+
+### `await bot.StopTypingAsync(userId)`
+
+Cancels the typing indicator.
+
+### `await bot.SendAsync(userId, text)`
+
+Sends a proactive text message using the cached `context_token` for that user.
+
+### `await bot.RunAsync()`
+
+Starts the long-poll loop, dispatches inbound messages, retries transient failures, and forces a fresh QR login when the session expires.
+
+### `bot.Stop()`
+
+Stops the long-poll loop gracefully.
+
+## Behavior
+
+1. `LoginAsync()` fetches a QR login URL, waits for WeChat confirmation, and stores the returned credentials at `~/.weixin-bot/credentials.json`.
+2. `RunAsync()` performs long polling against `getupdates`.
+3. Each inbound user message is converted into `IncomingMessage`.
+4. `ReplyAsync()` and `SendAsync()` reuse the internally managed `context_token`.
+5. When the API returns `errcode = -14`, the SDK clears saved credentials, requests a fresh QR login, and resumes polling with exponential backoff.
+
+## Protocol
+
+See [../PROTOCOL.md](../PROTOCOL.md) for the wire protocol used by this SDK.

--- a/dotnet/examples/EchoBot/EchoBot.csproj
+++ b/dotnet/examples/EchoBot/EchoBot.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pinix.WeixinBot\Pinix.WeixinBot.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/examples/EchoBot/Program.cs
+++ b/dotnet/examples/EchoBot/Program.cs
@@ -1,0 +1,21 @@
+using Pinix.WeixinBot;
+
+var bot = new WeixinBot();
+await bot.LoginAsync();
+
+bot.OnMessage(async message =>
+{
+    Console.WriteLine($"[{message.Timestamp:HH:mm:ss}] {message.UserId}: {message.Text}");
+    await bot.SendTypingAsync(message.UserId);
+    await bot.ReplyAsync(message, $"你说了: {message.Text}");
+});
+
+Console.WriteLine("Bot is running. Press Ctrl+C to stop.");
+
+Console.CancelKeyPress += (_, eventArgs) =>
+{
+    eventArgs.Cancel = true;
+    bot.Stop();
+};
+
+await bot.RunAsync();

--- a/dotnet/src/Pinix.WeixinBot/Api.cs
+++ b/dotnet/src/Pinix.WeixinBot/Api.cs
@@ -1,0 +1,414 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Pinix.WeixinBot;
+
+public sealed class ApiException : Exception
+{
+    public ApiException(string message, int statusCode, int? errorCode = null, string? responseBody = null)
+        : base(message)
+    {
+        StatusCode = statusCode;
+        ErrorCode = errorCode;
+        ResponseBody = responseBody;
+    }
+
+    public int StatusCode { get; }
+
+    public int? ErrorCode { get; }
+
+    public string? ResponseBody { get; }
+
+    public bool IsSessionExpired => ErrorCode == -14;
+}
+
+public static class WeixinBotDefaults
+{
+    public const string BaseUrl = "https://ilinkai.weixin.qq.com";
+    public const string ChannelVersion = "1.0.0";
+}
+
+internal static class WeixinBotApi
+{
+    private static readonly HttpClient HttpClient = new()
+    {
+        Timeout = Timeout.InfiniteTimeSpan,
+    };
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    internal static string RandomWeChatUin()
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        RandomNumberGenerator.Fill(buffer);
+        var value = BinaryPrimitives.ReadUInt32BigEndian(buffer);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+    }
+
+    internal static async Task<GetUpdatesResponse> GetUpdatesAsync(
+        string baseUrl,
+        string token,
+        string cursor,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetUpdatesRequest
+        {
+            GetUpdatesBuffer = cursor,
+            BaseInfo = BuildBaseInfo(),
+        };
+
+        return await PostAsync<GetUpdatesResponse>(
+            baseUrl,
+            "/ilink/bot/getupdates",
+            request,
+            token,
+            40_000,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task SendMessageAsync(
+        string baseUrl,
+        string token,
+        SendMessagePayload message,
+        CancellationToken cancellationToken)
+    {
+        var request = new SendMessageRequest
+        {
+            Message = message,
+            BaseInfo = BuildBaseInfo(),
+        };
+
+        await PostAsync<JsonElement>(
+            baseUrl,
+            "/ilink/bot/sendmessage",
+            request,
+            token,
+            15_000,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<GetConfigResponse> GetConfigAsync(
+        string baseUrl,
+        string token,
+        string userId,
+        string contextToken,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetConfigRequest
+        {
+            ILinkUserId = userId,
+            ContextToken = contextToken,
+            BaseInfo = BuildBaseInfo(),
+        };
+
+        return await PostAsync<GetConfigResponse>(
+            baseUrl,
+            "/ilink/bot/getconfig",
+            request,
+            token,
+            15_000,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task SendTypingAsync(
+        string baseUrl,
+        string token,
+        string userId,
+        string ticket,
+        int status,
+        CancellationToken cancellationToken)
+    {
+        var request = new SendTypingRequest
+        {
+            ILinkUserId = userId,
+            TypingTicket = ticket,
+            Status = status,
+            BaseInfo = BuildBaseInfo(),
+        };
+
+        await PostAsync<JsonElement>(
+            baseUrl,
+            "/ilink/bot/sendtyping",
+            request,
+            token,
+            15_000,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<QrCodeResponse> FetchQrCodeAsync(string baseUrl, CancellationToken cancellationToken)
+    {
+        return await GetAsync<QrCodeResponse>(
+            baseUrl,
+            "/ilink/bot/get_bot_qrcode?bot_type=3",
+            timeoutMilliseconds: 15_000,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<QrStatusResponse> PollQrStatusAsync(
+        string baseUrl,
+        string qrCode,
+        CancellationToken cancellationToken)
+    {
+        return await GetAsync<QrStatusResponse>(
+            baseUrl,
+            $"/ilink/bot/get_qrcode_status?qrcode={Uri.EscapeDataString(qrCode)}",
+            headers: new Dictionary<string, string>
+            {
+                ["iLink-App-ClientVersion"] = "1",
+            },
+            timeoutMilliseconds: 15_000,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static SendMessagePayload BuildTextMessage(string userId, string contextToken, string text)
+    {
+        return new SendMessagePayload
+        {
+            FromUserId = string.Empty,
+            ToUserId = userId,
+            ClientId = Guid.NewGuid().ToString(),
+            MessageType = MessageType.Bot,
+            MessageState = MessageState.Finish,
+            ContextToken = contextToken,
+            ItemList =
+            [
+                new MessageItem
+                {
+                    Type = MessageItemType.Text,
+                    TextItem = new TextItem
+                    {
+                        Text = text,
+                    },
+                },
+            ],
+        };
+    }
+
+    private static BaseInfo BuildBaseInfo()
+    {
+        return new BaseInfo
+        {
+            ChannelVersion = WeixinBotDefaults.ChannelVersion,
+        };
+    }
+
+    private static async Task<T> PostAsync<T>(
+        string baseUrl,
+        string path,
+        object body,
+        string token,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, BuildUri(baseUrl, path))
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(body, JsonOptions),
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+        foreach (var header in BuildHeaders(token))
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        return await SendAsync<T>(request, path, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> GetAsync<T>(
+        string baseUrl,
+        string path,
+        IReadOnlyDictionary<string, string>? headers = null,
+        int timeoutMilliseconds = 15_000,
+        CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, BuildUri(baseUrl, path));
+
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        return await SendAsync<T>(request, path, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> SendAsync<T>(
+        HttpRequestMessage request,
+        string label,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeoutMilliseconds);
+
+        try
+        {
+            using var response = await HttpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeoutSource.Token).ConfigureAwait(false);
+
+            var payloadText = await response.Content.ReadAsStringAsync(timeoutSource.Token).ConfigureAwait(false);
+            return ParseJsonResponse<T>(payloadText, (int)response.StatusCode, label);
+        }
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"{label} timed out after {timeoutMilliseconds} ms.", exception);
+        }
+        catch (HttpRequestException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new IOException($"{label} request failed: {exception.Message}", exception);
+        }
+    }
+
+    private static T ParseJsonResponse<T>(string payloadText, int statusCode, string label)
+    {
+        var normalizedPayload = string.IsNullOrWhiteSpace(payloadText) ? "{}" : payloadText;
+        using var document = JsonDocument.Parse(normalizedPayload);
+        var root = document.RootElement;
+
+        if (statusCode is < 200 or >= 300)
+        {
+            throw new ApiException(
+                GetString(root, "errmsg") ?? $"{label} failed with HTTP {statusCode}",
+                statusCode,
+                GetInt32(root, "errcode"),
+                normalizedPayload);
+        }
+
+        if (root.TryGetProperty("ret", out var retValue)
+            && retValue.ValueKind == JsonValueKind.Number
+            && retValue.GetInt32() != 0)
+        {
+            var errorCode = GetInt32(root, "errcode") ?? retValue.GetInt32();
+            throw new ApiException(
+                GetString(root, "errmsg") ?? $"{label} failed",
+                statusCode,
+                errorCode,
+                normalizedPayload);
+        }
+
+        var result = JsonSerializer.Deserialize<T>(normalizedPayload, JsonOptions);
+        if (result is null)
+        {
+            throw new InvalidOperationException($"{label} returned an empty JSON payload.");
+        }
+
+        return result;
+    }
+
+    private static Uri BuildUri(string baseUrl, string path)
+    {
+        return new(new Uri($"{baseUrl.TrimEnd('/')}/", UriKind.Absolute), path.TrimStart('/'));
+    }
+
+    private static Dictionary<string, string> BuildHeaders(string token)
+    {
+        return new Dictionary<string, string>
+        {
+            ["Content-Type"] = "application/json",
+            ["AuthorizationType"] = "ilink_bot_token",
+            ["Authorization"] = $"Bearer {token}",
+            ["X-WECHAT-UIN"] = RandomWeChatUin(),
+        };
+    }
+
+    private static string? GetString(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString();
+        }
+
+        return null;
+    }
+
+    private static int? GetInt32(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.Number)
+        {
+            return value.GetInt32();
+        }
+
+        return null;
+    }
+
+    private sealed class GetUpdatesRequest
+    {
+        [JsonPropertyName("get_updates_buf")]
+        public string GetUpdatesBuffer { get; init; } = string.Empty;
+
+        [JsonPropertyName("base_info")]
+        public BaseInfo BaseInfo { get; init; } = new();
+    }
+
+    private sealed class GetConfigRequest
+    {
+        [JsonPropertyName("ilink_user_id")]
+        public string ILinkUserId { get; init; } = string.Empty;
+
+        [JsonPropertyName("context_token")]
+        public string ContextToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("base_info")]
+        public BaseInfo BaseInfo { get; init; } = new();
+    }
+
+    private sealed class SendMessageRequest
+    {
+        [JsonPropertyName("msg")]
+        public SendMessagePayload Message { get; init; } = new();
+
+        [JsonPropertyName("base_info")]
+        public BaseInfo BaseInfo { get; init; } = new();
+    }
+
+    private sealed class SendTypingRequest
+    {
+        [JsonPropertyName("ilink_user_id")]
+        public string ILinkUserId { get; init; } = string.Empty;
+
+        [JsonPropertyName("typing_ticket")]
+        public string TypingTicket { get; init; } = string.Empty;
+
+        [JsonPropertyName("status")]
+        public int Status { get; init; }
+
+        [JsonPropertyName("base_info")]
+        public BaseInfo BaseInfo { get; init; } = new();
+    }
+
+    internal sealed class SendMessagePayload
+    {
+        [JsonPropertyName("from_user_id")]
+        public string FromUserId { get; init; } = string.Empty;
+
+        [JsonPropertyName("to_user_id")]
+        public string ToUserId { get; init; } = string.Empty;
+
+        [JsonPropertyName("client_id")]
+        public string ClientId { get; init; } = string.Empty;
+
+        [JsonPropertyName("message_type")]
+        public MessageType MessageType { get; init; }
+
+        [JsonPropertyName("message_state")]
+        public MessageState MessageState { get; init; }
+
+        [JsonPropertyName("context_token")]
+        public string ContextToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("item_list")]
+        public List<MessageItem> ItemList { get; init; } = [];
+    }
+}

--- a/dotnet/src/Pinix.WeixinBot/Auth.cs
+++ b/dotnet/src/Pinix.WeixinBot/Auth.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+
+namespace Pinix.WeixinBot;
+
+public sealed class Credentials
+{
+    public required string Token { get; init; }
+
+    public required string BaseUrl { get; init; }
+
+    public required string AccountId { get; init; }
+
+    public required string UserId { get; init; }
+}
+
+internal static class WeixinBotAuth
+{
+    private const int QrPollIntervalMilliseconds = 2_000;
+    private const int NetworkRetryDelayMilliseconds = 2_000;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    internal static readonly string DefaultTokenPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".weixin-bot",
+        "credentials.json");
+
+    internal static string ResolveTokenPath(string? tokenPath)
+    {
+        return string.IsNullOrWhiteSpace(tokenPath) ? DefaultTokenPath : tokenPath;
+    }
+
+    internal static async Task<Credentials?> LoadCredentialsAsync(
+        string? tokenPath,
+        CancellationToken cancellationToken)
+    {
+        var resolvedPath = ResolveTokenPath(tokenPath);
+        if (!File.Exists(resolvedPath))
+        {
+            return null;
+        }
+
+        var payload = await File.ReadAllTextAsync(resolvedPath, cancellationToken).ConfigureAwait(false);
+        using var document = JsonDocument.Parse(payload);
+        return ParseCredentials(document.RootElement, resolvedPath);
+    }
+
+    internal static Task ClearCredentialsAsync(string? tokenPath)
+    {
+        var resolvedPath = ResolveTokenPath(tokenPath);
+        if (File.Exists(resolvedPath))
+        {
+            File.Delete(resolvedPath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    internal static async Task<Credentials> LoginAsync(
+        string baseUrl,
+        string? tokenPath,
+        bool force,
+        Action<string> log,
+        CancellationToken cancellationToken)
+    {
+        if (!force)
+        {
+            var existing = await LoadCredentialsAsync(tokenPath, cancellationToken).ConfigureAwait(false);
+            if (existing is not null)
+            {
+                return existing;
+            }
+        }
+
+        while (true)
+        {
+            QrCodeResponse qr;
+            try
+            {
+                qr = await WeixinBotApi.FetchQrCodeAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (IsTransientLoginError(exception, cancellationToken))
+            {
+                log($"Failed to fetch QR code: {exception.Message}. Retrying...");
+                await Task.Delay(NetworkRetryDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            PrintQrInstructions(qr.QrCodeImageContent);
+
+            string? lastStatus = null;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                QrStatusResponse status;
+                try
+                {
+                    status = await WeixinBotApi.PollQrStatusAsync(baseUrl, qr.QrCode, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception exception) when (IsTransientLoginError(exception, cancellationToken))
+                {
+                    log($"QR status poll failed: {exception.Message}. Retrying...");
+                    await Task.Delay(NetworkRetryDelayMilliseconds, cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (!string.Equals(status.Status, lastStatus, StringComparison.Ordinal))
+                {
+                    if (string.Equals(status.Status, "scaned", StringComparison.Ordinal))
+                    {
+                        log("QR code scanned. Confirm the login inside WeChat.");
+                    }
+                    else if (string.Equals(status.Status, "confirmed", StringComparison.Ordinal))
+                    {
+                        log("Login confirmed.");
+                    }
+                    else if (string.Equals(status.Status, "expired", StringComparison.Ordinal))
+                    {
+                        log("QR code expired. Requesting a new one...");
+                    }
+
+                    lastStatus = status.Status;
+                }
+
+                if (string.Equals(status.Status, "confirmed", StringComparison.Ordinal))
+                {
+                    if (string.IsNullOrWhiteSpace(status.BotToken)
+                        || string.IsNullOrWhiteSpace(status.ILinkBotId)
+                        || string.IsNullOrWhiteSpace(status.ILinkUserId))
+                    {
+                        throw new InvalidOperationException("QR login confirmed, but the API did not return bot credentials.");
+                    }
+
+                    var credentials = new Credentials
+                    {
+                        Token = status.BotToken,
+                        BaseUrl = string.IsNullOrWhiteSpace(status.BaseUrl) ? baseUrl : status.BaseUrl,
+                        AccountId = status.ILinkBotId,
+                        UserId = status.ILinkUserId,
+                    };
+
+                    await SaveCredentialsAsync(credentials, tokenPath, cancellationToken).ConfigureAwait(false);
+                    return credentials;
+                }
+
+                if (string.Equals(status.Status, "expired", StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                await Task.Delay(QrPollIntervalMilliseconds, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task SaveCredentialsAsync(
+        Credentials credentials,
+        string? tokenPath,
+        CancellationToken cancellationToken)
+    {
+        var resolvedPath = ResolveTokenPath(tokenPath);
+        var directory = Path.GetDirectoryName(resolvedPath);
+
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var payload = JsonSerializer.Serialize(
+            new
+            {
+                token = credentials.Token,
+                baseUrl = credentials.BaseUrl,
+                accountId = credentials.AccountId,
+                userId = credentials.UserId,
+            },
+            JsonOptions);
+
+        await File.WriteAllTextAsync(resolvedPath, payload + Environment.NewLine, cancellationToken).ConfigureAwait(false);
+        TrySetPrivateFileMode(resolvedPath);
+    }
+
+    private static Credentials ParseCredentials(JsonElement root, string source)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException($"Invalid credentials format in {source}");
+        }
+
+        var token = GetString(root, "token");
+        var baseUrl = GetString(root, "base_url") ?? GetString(root, "baseUrl");
+        var accountId = GetString(root, "account_id") ?? GetString(root, "accountId");
+        var userId = GetString(root, "user_id") ?? GetString(root, "userId");
+
+        if (string.IsNullOrWhiteSpace(token)
+            || string.IsNullOrWhiteSpace(baseUrl)
+            || string.IsNullOrWhiteSpace(accountId)
+            || string.IsNullOrWhiteSpace(userId))
+        {
+            throw new InvalidOperationException($"Invalid credentials format in {source}");
+        }
+
+        return new Credentials
+        {
+            Token = token,
+            BaseUrl = baseUrl,
+            AccountId = accountId,
+            UserId = userId,
+        };
+    }
+
+    private static string? GetString(JsonElement root, string propertyName)
+    {
+        if (root.TryGetProperty(propertyName, out var propertyValue) && propertyValue.ValueKind == JsonValueKind.String)
+        {
+            return propertyValue.GetString();
+        }
+
+        return null;
+    }
+
+    private static void PrintQrInstructions(string url)
+    {
+        Console.Error.WriteLine("[weixin-bot] 在微信中打开以下链接完成登录:");
+        Console.Error.WriteLine(url);
+    }
+
+    private static void TrySetPrivateFileMode(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (Exception)
+        {
+            // Ignore permission setting errors to keep login flow functional across runtimes.
+        }
+    }
+
+    private static bool IsTransientLoginError(Exception exception, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+
+        return exception switch
+        {
+            TimeoutException => true,
+            IOException => true,
+            HttpRequestException => true,
+            ApiException apiException when apiException.StatusCode >= 500 => true,
+            OperationCanceledException => true,
+            _ => false,
+        };
+    }
+}

--- a/dotnet/src/Pinix.WeixinBot/Pinix.WeixinBot.csproj
+++ b/dotnet/src/Pinix.WeixinBot/Pinix.WeixinBot.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Pinix.WeixinBot</RootNamespace>
+    <PackageId>Pinix.WeixinBot</PackageId>
+    <Authors>Pinix</Authors>
+    <Description>.NET SDK for the WeChat iLink Bot API</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="/" Link="README.md" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/Pinix.WeixinBot/Types.cs
+++ b/dotnet/src/Pinix.WeixinBot/Types.cs
@@ -1,0 +1,263 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Pinix.WeixinBot;
+
+public enum MessageType
+{
+    User = 1,
+    Bot = 2,
+}
+
+public enum MessageState
+{
+    New = 0,
+    Generating = 1,
+    Finish = 2,
+}
+
+public enum MessageItemType
+{
+    Text = 1,
+    Image = 2,
+    Voice = 3,
+    File = 4,
+    Video = 5,
+}
+
+public sealed class BaseInfo
+{
+    [JsonPropertyName("channel_version")]
+    public string ChannelVersion { get; init; } = string.Empty;
+}
+
+public sealed class CdnMedia
+{
+    [JsonPropertyName("encrypt_query_param")]
+    public string EncryptQueryParam { get; init; } = string.Empty;
+
+    [JsonPropertyName("aes_key")]
+    public string AesKey { get; init; } = string.Empty;
+
+    [JsonPropertyName("encrypt_type")]
+    public int? EncryptType { get; init; }
+}
+
+public sealed class TextItem
+{
+    [JsonPropertyName("text")]
+    public string Text { get; init; } = string.Empty;
+}
+
+public sealed class ImageItem
+{
+    [JsonPropertyName("media")]
+    public CdnMedia? Media { get; init; }
+
+    [JsonPropertyName("aeskey")]
+    public string? AesKey { get; init; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    [JsonPropertyName("mid_size")]
+    public JsonElement? MidSize { get; init; }
+
+    [JsonPropertyName("thumb_size")]
+    public JsonElement? ThumbSize { get; init; }
+
+    [JsonPropertyName("thumb_height")]
+    public int? ThumbHeight { get; init; }
+
+    [JsonPropertyName("thumb_width")]
+    public int? ThumbWidth { get; init; }
+
+    [JsonPropertyName("hd_size")]
+    public JsonElement? HdSize { get; init; }
+}
+
+public sealed class VoiceItem
+{
+    [JsonPropertyName("media")]
+    public CdnMedia? Media { get; init; }
+
+    [JsonPropertyName("encode_type")]
+    public int? EncodeType { get; init; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    [JsonPropertyName("playtime")]
+    public int? PlayTime { get; init; }
+}
+
+public sealed class FileItem
+{
+    [JsonPropertyName("media")]
+    public CdnMedia? Media { get; init; }
+
+    [JsonPropertyName("file_name")]
+    public string? FileName { get; init; }
+
+    [JsonPropertyName("md5")]
+    public string? Md5 { get; init; }
+
+    [JsonPropertyName("len")]
+    public string? Length { get; init; }
+}
+
+public sealed class VideoItem
+{
+    [JsonPropertyName("media")]
+    public CdnMedia? Media { get; init; }
+
+    [JsonPropertyName("video_size")]
+    public JsonElement? VideoSize { get; init; }
+
+    [JsonPropertyName("play_length")]
+    public int? PlayLength { get; init; }
+
+    [JsonPropertyName("thumb_media")]
+    public CdnMedia? ThumbMedia { get; init; }
+}
+
+public sealed class RefMessage
+{
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("message_item")]
+    public MessageItem? MessageItem { get; init; }
+}
+
+public sealed class MessageItem
+{
+    [JsonPropertyName("type")]
+    public MessageItemType Type { get; init; }
+
+    [JsonPropertyName("text_item")]
+    public TextItem? TextItem { get; init; }
+
+    [JsonPropertyName("image_item")]
+    public ImageItem? ImageItem { get; init; }
+
+    [JsonPropertyName("voice_item")]
+    public VoiceItem? VoiceItem { get; init; }
+
+    [JsonPropertyName("file_item")]
+    public FileItem? FileItem { get; init; }
+
+    [JsonPropertyName("video_item")]
+    public VideoItem? VideoItem { get; init; }
+
+    [JsonPropertyName("ref_msg")]
+    public RefMessage? RefMessage { get; init; }
+}
+
+public sealed class WeixinMessage
+{
+    [JsonPropertyName("message_id")]
+    public long MessageId { get; init; }
+
+    [JsonPropertyName("from_user_id")]
+    public string FromUserId { get; init; } = string.Empty;
+
+    [JsonPropertyName("to_user_id")]
+    public string ToUserId { get; init; } = string.Empty;
+
+    [JsonPropertyName("client_id")]
+    public string ClientId { get; init; } = string.Empty;
+
+    [JsonPropertyName("create_time_ms")]
+    public long CreateTimeMilliseconds { get; init; }
+
+    [JsonPropertyName("message_type")]
+    public MessageType MessageType { get; init; }
+
+    [JsonPropertyName("message_state")]
+    public MessageState MessageState { get; init; }
+
+    [JsonPropertyName("context_token")]
+    public string ContextToken { get; init; } = string.Empty;
+
+    [JsonPropertyName("item_list")]
+    public List<MessageItem> ItemList { get; init; } = [];
+}
+
+public sealed class GetUpdatesResponse
+{
+    [JsonPropertyName("ret")]
+    public int Ret { get; init; }
+
+    [JsonPropertyName("msgs")]
+    public List<WeixinMessage> Messages { get; init; } = [];
+
+    [JsonPropertyName("get_updates_buf")]
+    public string GetUpdatesBuffer { get; init; } = string.Empty;
+
+    [JsonPropertyName("longpolling_timeout_ms")]
+    public int? LongPollingTimeoutMilliseconds { get; init; }
+
+    [JsonPropertyName("errcode")]
+    public int? ErrorCode { get; init; }
+
+    [JsonPropertyName("errmsg")]
+    public string? ErrorMessage { get; init; }
+}
+
+public sealed class GetConfigResponse
+{
+    [JsonPropertyName("typing_ticket")]
+    public string? TypingTicket { get; init; }
+
+    [JsonPropertyName("ret")]
+    public int? Ret { get; init; }
+
+    [JsonPropertyName("errcode")]
+    public int? ErrorCode { get; init; }
+
+    [JsonPropertyName("errmsg")]
+    public string? ErrorMessage { get; init; }
+}
+
+public sealed class QrCodeResponse
+{
+    [JsonPropertyName("qrcode")]
+    public string QrCode { get; init; } = string.Empty;
+
+    [JsonPropertyName("qrcode_img_content")]
+    public string QrCodeImageContent { get; init; } = string.Empty;
+}
+
+public sealed class QrStatusResponse
+{
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    [JsonPropertyName("bot_token")]
+    public string? BotToken { get; init; }
+
+    [JsonPropertyName("ilink_bot_id")]
+    public string? ILinkBotId { get; init; }
+
+    [JsonPropertyName("ilink_user_id")]
+    public string? ILinkUserId { get; init; }
+
+    [JsonPropertyName("baseurl")]
+    public string? BaseUrl { get; init; }
+}
+
+public sealed class IncomingMessage
+{
+    public required string UserId { get; init; }
+
+    public required string Text { get; init; }
+
+    public required string Type { get; init; }
+
+    public required WeixinMessage Raw { get; init; }
+
+    public required DateTimeOffset Timestamp { get; init; }
+
+    internal string ContextToken { get; init; } = string.Empty;
+}

--- a/dotnet/src/Pinix.WeixinBot/WeixinBot.cs
+++ b/dotnet/src/Pinix.WeixinBot/WeixinBot.cs
@@ -1,0 +1,522 @@
+using System.Collections.Concurrent;
+
+namespace Pinix.WeixinBot;
+
+public sealed class WeixinBotOptions
+{
+    public string? BaseUrl { get; init; }
+
+    public string? TokenPath { get; init; }
+
+    public Action<Exception>? OnError { get; init; }
+}
+
+public sealed class WeixinBot
+{
+    private readonly object _gate = new();
+    private readonly List<Func<IncomingMessage, Task>> _handlers = [];
+    private readonly ConcurrentDictionary<string, string> _contextTokens = new();
+    private readonly string? _tokenPath;
+    private readonly Action<Exception>? _onError;
+
+    private string _baseUrl;
+    private Credentials? _credentials;
+    private string _cursor = string.Empty;
+    private bool _stopped;
+    private CancellationTokenSource? _runCancellationSource;
+    private CancellationTokenSource? _currentPollCancellationSource;
+    private Task? _runTask;
+
+    public WeixinBot(WeixinBotOptions? options = null)
+    {
+        _baseUrl = options?.BaseUrl ?? WeixinBotDefaults.BaseUrl;
+        _tokenPath = options?.TokenPath;
+        _onError = options?.OnError;
+    }
+
+    public static string DefaultTokenPath => WeixinBotAuth.DefaultTokenPath;
+
+    public WeixinBot OnMessage(Func<IncomingMessage, Task> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _handlers.Add(handler);
+        return this;
+    }
+
+    public WeixinBot OnMessage(Action<IncomingMessage> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        return OnMessage(message =>
+        {
+            handler(message);
+            return Task.CompletedTask;
+        });
+    }
+
+    public WeixinBot On(string eventName, Func<IncomingMessage, Task> handler)
+    {
+        if (!string.Equals(eventName, "message", StringComparison.Ordinal))
+        {
+            throw new NotSupportedException($"Unsupported event: {eventName}");
+        }
+
+        return OnMessage(handler);
+    }
+
+    public WeixinBot On(string eventName, Action<IncomingMessage> handler)
+    {
+        if (!string.Equals(eventName, "message", StringComparison.Ordinal))
+        {
+            throw new NotSupportedException($"Unsupported event: {eventName}");
+        }
+
+        return OnMessage(handler);
+    }
+
+    public async Task<Credentials> LoginAsync(bool force = false, CancellationToken cancellationToken = default)
+    {
+        var previousToken = _credentials?.Token;
+        var credentials = await WeixinBotAuth.LoginAsync(
+            _baseUrl,
+            _tokenPath,
+            force,
+            Log,
+            cancellationToken).ConfigureAwait(false);
+
+        _credentials = credentials;
+        _baseUrl = credentials.BaseUrl;
+
+        if (!string.IsNullOrWhiteSpace(previousToken)
+            && !string.Equals(previousToken, credentials.Token, StringComparison.Ordinal))
+        {
+            _cursor = string.Empty;
+            _contextTokens.Clear();
+        }
+
+        Log($"Logged in as {credentials.UserId}");
+        return credentials;
+    }
+
+    public async Task ReplyAsync(
+        IncomingMessage message,
+        string text,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        _contextTokens[message.UserId] = message.ContextToken;
+        await SendTextAsync(message.UserId, text, message.ContextToken, cancellationToken).ConfigureAwait(false);
+        IgnoreFault(StopTypingAsync(message.UserId));
+    }
+
+    public async Task SendTypingAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        if (!_contextTokens.TryGetValue(userId, out var contextToken))
+        {
+            throw new InvalidOperationException($"No cached context token for user {userId}. Reply to an incoming message first.");
+        }
+
+        var credentials = await EnsureCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        var config = await WeixinBotApi.GetConfigAsync(
+            _baseUrl,
+            credentials.Token,
+            userId,
+            contextToken,
+            cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(config.TypingTicket))
+        {
+            Log("sendTyping: no typing_ticket returned by getconfig");
+            return;
+        }
+
+        await WeixinBotApi.SendTypingAsync(
+            _baseUrl,
+            credentials.Token,
+            userId,
+            config.TypingTicket,
+            status: 1,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task StopTypingAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        if (!_contextTokens.TryGetValue(userId, out var contextToken))
+        {
+            return;
+        }
+
+        var credentials = await EnsureCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        var config = await WeixinBotApi.GetConfigAsync(
+            _baseUrl,
+            credentials.Token,
+            userId,
+            contextToken,
+            cancellationToken).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(config.TypingTicket))
+        {
+            return;
+        }
+
+        await WeixinBotApi.SendTypingAsync(
+            _baseUrl,
+            credentials.Token,
+            userId,
+            config.TypingTicket,
+            status: 2,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task SendAsync(string userId, string text, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        if (!_contextTokens.TryGetValue(userId, out var contextToken))
+        {
+            throw new InvalidOperationException($"No cached context token for user {userId}. Reply to an incoming message first.");
+        }
+
+        await SendTextAsync(userId, text, contextToken, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_runTask is not null)
+            {
+                return _runTask;
+            }
+
+            _stopped = false;
+            _runCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _runTask = RunAndCleanupAsync(_runCancellationSource.Token);
+            return _runTask;
+        }
+    }
+
+    public void Stop()
+    {
+        _stopped = true;
+
+        lock (_gate)
+        {
+            _currentPollCancellationSource?.Cancel();
+            _runCancellationSource?.Cancel();
+        }
+    }
+
+    private async Task RunAndCleanupAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await RunLoopAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_gate)
+            {
+                _currentPollCancellationSource?.Dispose();
+                _currentPollCancellationSource = null;
+                _runCancellationSource?.Dispose();
+                _runCancellationSource = null;
+                _runTask = null;
+            }
+        }
+    }
+
+    private async Task RunLoopAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await EnsureCredentialsAsync(cancellationToken).ConfigureAwait(false);
+            Log("Long-poll loop started.");
+            var retryDelay = TimeSpan.FromSeconds(1);
+
+            while (!_stopped && !cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var credentials = await EnsureCredentialsAsync(cancellationToken).ConfigureAwait(false);
+                    using var pollCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    SetCurrentPollCancellationSource(pollCancellationSource);
+
+                    var updates = await WeixinBotApi.GetUpdatesAsync(
+                        _baseUrl,
+                        credentials.Token,
+                        _cursor,
+                        pollCancellationSource.Token).ConfigureAwait(false);
+
+                    ClearCurrentPollCancellationSource(pollCancellationSource);
+                    _cursor = string.IsNullOrWhiteSpace(updates.GetUpdatesBuffer) ? _cursor : updates.GetUpdatesBuffer;
+                    retryDelay = TimeSpan.FromSeconds(1);
+
+                    foreach (var rawMessage in updates.Messages)
+                    {
+                        RememberContext(rawMessage);
+                        var incomingMessage = ToIncomingMessage(rawMessage);
+                        if (incomingMessage is null)
+                        {
+                            continue;
+                        }
+
+                        await DispatchMessageAsync(incomingMessage).ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException) when (_stopped || cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception error)
+                {
+                    ClearCurrentPollCancellationSource(null);
+
+                    if (IsSessionExpired(error))
+                    {
+                        Log("Session expired. Waiting for a fresh QR login...");
+                        _credentials = null;
+                        _cursor = string.Empty;
+                        _contextTokens.Clear();
+
+                        try
+                        {
+                            await WeixinBotAuth.ClearCredentialsAsync(_tokenPath).ConfigureAwait(false);
+                            await LoginAsync(force: true, cancellationToken).ConfigureAwait(false);
+                            retryDelay = TimeSpan.FromSeconds(1);
+                            continue;
+                        }
+                        catch (Exception loginError)
+                        {
+                            ReportError(loginError);
+                        }
+                    }
+                    else
+                    {
+                        ReportError(error);
+                    }
+
+                    try
+                    {
+                        await Task.Delay(retryDelay, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (_stopped || cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    var nextDelaySeconds = Math.Min(retryDelay.TotalSeconds * 2, 10);
+                    retryDelay = TimeSpan.FromSeconds(nextDelaySeconds);
+                }
+            }
+        }
+        finally
+        {
+            Log("Long-poll loop stopped.");
+        }
+    }
+
+    private async Task<Credentials> EnsureCredentialsAsync(CancellationToken cancellationToken)
+    {
+        if (_credentials is not null)
+        {
+            return _credentials;
+        }
+
+        var stored = await WeixinBotAuth.LoadCredentialsAsync(_tokenPath, cancellationToken).ConfigureAwait(false);
+        if (stored is not null)
+        {
+            _credentials = stored;
+            _baseUrl = stored.BaseUrl;
+            return stored;
+        }
+
+        return await LoginAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendTextAsync(
+        string userId,
+        string text,
+        string contextToken,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            throw new ArgumentException("Message text cannot be empty.", nameof(text));
+        }
+
+        var credentials = await EnsureCredentialsAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var chunk in ChunkText(text, 2_000))
+        {
+            await WeixinBotApi.SendMessageAsync(
+                _baseUrl,
+                credentials.Token,
+                WeixinBotApi.BuildTextMessage(userId, contextToken, chunk),
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task DispatchMessageAsync(IncomingMessage message)
+    {
+        if (_handlers.Count == 0)
+        {
+            return;
+        }
+
+        var tasks = _handlers.Select(handler => InvokeHandlerAsync(handler, message)).ToArray();
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private async Task InvokeHandlerAsync(Func<IncomingMessage, Task> handler, IncomingMessage message)
+    {
+        try
+        {
+            await handler(message).ConfigureAwait(false);
+        }
+        catch (Exception error)
+        {
+            ReportError(error);
+        }
+    }
+
+    private void RememberContext(WeixinMessage message)
+    {
+        var userId = message.MessageType == MessageType.User ? message.FromUserId : message.ToUserId;
+        if (!string.IsNullOrWhiteSpace(userId) && !string.IsNullOrWhiteSpace(message.ContextToken))
+        {
+            _contextTokens[userId] = message.ContextToken;
+        }
+    }
+
+    private IncomingMessage? ToIncomingMessage(WeixinMessage message)
+    {
+        if (message.MessageType != MessageType.User)
+        {
+            return null;
+        }
+
+        return new IncomingMessage
+        {
+            UserId = message.FromUserId,
+            Text = ExtractText(message.ItemList),
+            Type = DetectType(message.ItemList),
+            Raw = message,
+            ContextToken = message.ContextToken,
+            Timestamp = DateTimeOffset.FromUnixTimeMilliseconds(message.CreateTimeMilliseconds).ToLocalTime(),
+        };
+    }
+
+    private static string DetectType(IReadOnlyList<MessageItem> items)
+    {
+        if (items.Count == 0)
+        {
+            return "text";
+        }
+
+        return items[0].Type switch
+        {
+            MessageItemType.Image => "image",
+            MessageItemType.Voice => "voice",
+            MessageItemType.File => "file",
+            MessageItemType.Video => "video",
+            _ => "text",
+        };
+    }
+
+    private static string ExtractText(IEnumerable<MessageItem> items)
+    {
+        var parts = new List<string>();
+
+        foreach (var item in items)
+        {
+            var text = item.Type switch
+            {
+                MessageItemType.Text => item.TextItem?.Text ?? string.Empty,
+                MessageItemType.Image => item.ImageItem?.Url ?? "[image]",
+                MessageItemType.Voice => item.VoiceItem?.Text ?? "[voice]",
+                MessageItemType.File => item.FileItem?.FileName ?? "[file]",
+                MessageItemType.Video => "[video]",
+                _ => string.Empty,
+            };
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                parts.Add(text);
+            }
+        }
+
+        return string.Join(Environment.NewLine, parts);
+    }
+
+    private static IEnumerable<string> ChunkText(string text, int limit)
+    {
+        for (var index = 0; index < text.Length; index += limit)
+        {
+            yield return text.Substring(index, Math.Min(limit, text.Length - index));
+        }
+    }
+
+    private static bool IsSessionExpired(Exception error)
+    {
+        return error is ApiException apiException && apiException.IsSessionExpired;
+    }
+
+    private static void IgnoreFault(Task task)
+    {
+        _ = task.ContinueWith(
+            _ => { },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+
+    private void ReportError(Exception error)
+    {
+        Log(error.Message);
+
+        if (_onError is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _onError(error);
+        }
+        catch (Exception callbackError)
+        {
+            Log($"onError callback failed: {callbackError.Message}");
+        }
+    }
+
+    private void Log(string message)
+    {
+        Console.Error.WriteLine($"[weixin-bot] {message}");
+    }
+
+    private void SetCurrentPollCancellationSource(CancellationTokenSource source)
+    {
+        lock (_gate)
+        {
+            _currentPollCancellationSource?.Dispose();
+            _currentPollCancellationSource = source;
+        }
+    }
+
+    private void ClearCurrentPollCancellationSource(CancellationTokenSource? expectedSource)
+    {
+        lock (_gate)
+        {
+            if (expectedSource is not null && !ReferenceEquals(_currentPollCancellationSource, expectedSource))
+            {
+                return;
+            }
+
+            _currentPollCancellationSource?.Dispose();
+            _currentPollCancellationSource = null;
+        }
+    }
+}


### PR DESCRIPTION
Implement a .NET 9 WeChat iLink Bot SDK with QR login, long polling, context token management, typing support, and automatic session recovery.

Add a runnable EchoBot example, document .NET usage in the repo README, and ignore .NET build artifacts.

Improve login robustness by retrying transient QR polling and network timeout failures.